### PR TITLE
fix DISPLAY detection and old widgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.beam
 *.o
+startup_error_report

--- a/lib/ex11_lib.erl
+++ b/lib/ex11_lib.erl
@@ -116,7 +116,7 @@
 colors() -> ex11_lib_rgb:colors().
 
 xStart() ->
-  xStart(":0.0").
+  xStart(os:getenv("DISPLAY", ":0.0")).
 xStart(Display) ->
   case ex11_lib_control:start(Display) of
     {ok, Pid, Screen} ->

--- a/lib/hello_buttons.erl
+++ b/lib/hello_buttons.erl
@@ -29,7 +29,7 @@
 		   xFlush/1,
 		   xGC/2,
 		   xSpawn/1,
-		   xStart/1]).
+		   xStart/0]).
 
 -export([start/0]).
 
@@ -41,7 +41,7 @@ start() ->
     spawn_link(fun() -> init() end).
 
 init() ->
-    {ok,Pid}   = xStart("3.2"),
+    {ok,Pid}   = xStart(),
     spawn(fun()  -> win1(Pid) end),
     spawn(fun()  -> win2(Pid) end),
     spawn(fun()  -> win3(Pid) end),

--- a/lib/hello_world.erl
+++ b/lib/hello_world.erl
@@ -27,7 +27,7 @@ start() ->
     spawn_link(fun() -> init() end).
 
 init() ->
-    {ok, Pid} = ex11_lib:xStart(":1.0"),
+    {ok, Pid} = ex11_lib:xStart(os:getenv("DISPLAY", ":1.0")),
     Win  = xCreateSimpleWindow(Pid, 10, 10, 300, 100, ?XC_arrow, 
 			       xColor(Pid, ?wheat2)),
     Font = xEnsureFont(Pid, "9x15"),  

--- a/lib/startup_error_report
+++ b/lib/startup_error_report
@@ -1,9 +1,0 @@
-$DISPLAY = :0.0
-parsed display Host=none DisplayNumber=0 ScreenNumber=0
-inet:gethostname() = "enfield"
-Es
-{ip,"193.10.65.254","Code1"}
-{unix,"enfield.sics.se","Code1"}
-Try list
-{unix,0,"Code1"}
-{{ip,"localhost"},0,"Code1"}

--- a/old_widgets/emacs.erl
+++ b/old_widgets/emacs.erl
@@ -15,7 +15,7 @@
 
 -export([start/0, start/1]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -import(ex11_lib, [rpc/2]).
 -import(lists, [foldl/3,reverse/1, reverse/2]).
 
@@ -40,7 +40,7 @@ start(File) ->
     spawn(fun() -> win(File) end).
 		  
 win(File) ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win     = swTopLevel:make(Display, 716, 390, ?bg),
     Text    = swEdText:make(Win, 10,10,696, 370,1,?white),
     Lines = read_file(File),

--- a/old_widgets/emacs1.erl
+++ b/old_widgets/emacs1.erl
@@ -17,7 +17,7 @@
 
 -export([start/0, start/1]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -import(ex11_lib, [rpc/2]).
 -import(lists, [duplicate/2,foldl/3,reverse/1, reverse/2]).
 
@@ -42,7 +42,7 @@ start(File) ->
     spawn(fun() -> win(File) end).
 		  
 win(File) ->
-    Display = xStart("3.2"), 
+    Display = xStart(),
     XX = 80, YY=10,
     {Width, Ht} = sw:sizeInCols2pixels(XX, YY),
     Win     = swTopLevel:make(Display, Width+20, Ht+20, ?bg),

--- a/old_widgets/example0.erl
+++ b/old_widgets/example0.erl
@@ -9,7 +9,7 @@
 
 -export([start/0]).
 
--import(sw, [mkTopLevel/4,xStart/1]).
+-import(sw, [mkTopLevel/4,xStart/0]).
 
 -include("sw.hrl").
 -define(bg, 16#ffffcc).
@@ -18,7 +18,7 @@ start() ->
     spawn(fun() -> win(examples1()) end).
 
 win(Examples) ->
-    Connection = xStart("3.1"),
+    Connection = xStart(),
     Ht = 35 * length(Examples) + 20,
     Win  = swTopLevel:make(Connection, 290, Ht, ?bg),
     add_examples(Win, 10, 10, 240, Examples),

--- a/old_widgets/example1.erl
+++ b/old_widgets/example1.erl
@@ -11,7 +11,7 @@
 
 -include("sw.hrl").
 
--import(sw, [mkTopLevel/4,xStart/1]).
+-import(sw, [mkTopLevel/4,xStart/0]).
 
 -define(bg, 16#ffffcc).
 
@@ -19,7 +19,7 @@ start() ->
     spawn_link(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win     = swTopLevel:make(Display, 160, 50, ?bg),
     Button  = swButton:make(Win, 10, 10, 120, 30, ?grey88, "Hello"),
     Button  ! {onClick, fun(X) -> io:format("Click ~p~n",[X]) end},

--- a/old_widgets/example10.erl
+++ b/old_widgets/example10.erl
@@ -11,7 +11,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1, rpc/2]).
+-import(sw, [xStart/0, rpc/2]).
 
 -include("sw.hrl").
 
@@ -20,7 +20,7 @@
 start() -> spawn(fun shell/0).
 
 shell() ->
-    Display = xStart("3.1"),
+    Display = xStart(),
     Width = 650,
     Ht    = 350,
     Win   = swTopLevel:make(Display, Width, Ht, ?bg),

--- a/old_widgets/example11.erl
+++ b/old_widgets/example11.erl
@@ -9,7 +9,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -import(ex11_lib, [rpc/2]).
 
 -include("sw.hrl").
@@ -20,7 +20,7 @@ start() ->
     spawn_link(fun win/0).
 
 win() ->
-    Display = xStart("3.1"),
+    Display = xStart(),
     Width = 950,
     Ht = 350,
     Win  = swTopLevel:make(Display, Width, Ht, ?bg),

--- a/old_widgets/example12.erl
+++ b/old_widgets/example12.erl
@@ -9,7 +9,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1, rpc/2]).
+-import(sw, [xStart/0, rpc/2]).
 
 -import(lists, [map/2, mapfoldl/3, max/1]).
 
@@ -42,7 +42,7 @@ form_widget(S, Len, Labels) ->
     WidthEntry = 9*Len+20,
     Width = WidthEntry + WidthLabel+40,
     Ht = length(Labels)*30 + 65,
-    Display = xStart("3.1"),
+    Display = xStart(),
     Win  = swTopLevel:make(Display,Width, Ht, ?bg),
     {Pids,Y1} = mapfoldl(fun(Txt,Y) ->
 				 mkLabel1(Win, 10, Y, WidthLabel, Txt),

--- a/old_widgets/example13.erl
+++ b/old_widgets/example13.erl
@@ -12,7 +12,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 
 -include("sw.hrl").
 
@@ -22,7 +22,7 @@ start() ->
     spawn(fun win/0).
 
 win() ->
-    Display = xStart("3.1"),
+    Display = xStart(),
     Win  = swTopLevel:make(Display, 800, 600, ?bg),
     W1 = dragFrame(Win, 10, 30, 400, 200, ?blue),
     swButton:make(W1, 10, 14, 120, 30, ?green, "Erlang"),

--- a/old_widgets/example14.erl
+++ b/old_widgets/example14.erl
@@ -9,7 +9,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 
 -include("sw.hrl").
 
@@ -19,7 +19,7 @@ start() ->
     spawn(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win  =  swTopLevel:make(Display,800, 600, ?bg),
     X0 = 360, Y0=100,
     Dx1 = -150, Dy1 = 125,

--- a/old_widgets/example15.erl
+++ b/old_widgets/example15.erl
@@ -9,7 +9,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -import(ex11_lib, [xDo/2, eGetKeyboardMapping/2]).
 -import(lists, [foreach/2]).
 
@@ -21,7 +21,7 @@ start() ->
     spawn(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     {First,Last} = K = ex11_lib:get_display(Display, keycodes),
     io:format("K=~p~n",[K]),
     {ok, {keys, Val}} = xDo(Display, eGetKeyboardMapping(First,Last)),

--- a/old_widgets/example16.erl
+++ b/old_widgets/example16.erl
@@ -20,13 +20,13 @@
 		   xSetVar/3]).
 
 -import(lists, [foldl/3, mapfoldl/3, max/1, map/2]).
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 
 start() ->
     spawn(fun() -> win() end).
 
 win() ->
-    Display = xStart("3.1"),
+    Display = xStart(),
     Win  =  swTopLevel:make(Display,400, 300, ?bg),
     Button = swButton:make(Win, 10, 10, 120, 30, ?yellow, "Hide Menu"),
     Pop = pop(Win, 10, 50, 120, ["one", "two", "three", "four","six",

--- a/old_widgets/example17.erl
+++ b/old_widgets/example17.erl
@@ -9,7 +9,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 
 -include("sw.hrl").
 
@@ -19,7 +19,7 @@ start() ->
     spawn(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win  = swTopLevel:make(Display,800, 70, ?bg),
     Rect = swRectangle:make(Win, 10, 10, 50, 50, 1, ?red),
     loop(370, Rect).

--- a/old_widgets/example18.erl
+++ b/old_widgets/example18.erl
@@ -16,7 +16,7 @@
 
 -import(ex11_lib,[colors/0]).
 -import(lists, [map/2,reverse/1,seq/2]).
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -include("sw.hrl").
 
 -define(bg, 16#ffffcc).
@@ -29,7 +29,7 @@ win() ->
     Size=  18,
     Gap = 6, 
     Colors = colors(), 
-    Display = xStart("3.1"),
+    Display = xStart(),
     make_page(Display, Colors, Rows, Cols, Size, Gap),
     loop(Display).
 

--- a/old_widgets/example19.erl
+++ b/old_widgets/example19.erl
@@ -11,7 +11,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 
 -include("sw.hrl").
 
@@ -20,7 +20,7 @@
 start() -> spawn(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win     = swTopLevel:make(Display, 400, 250, ?bg),
     XX = 10, YY=10,
     DragBar   = swDragBox  :make(Win, XX, YY,    260, 10, 1,?blue),

--- a/old_widgets/example2.erl
+++ b/old_widgets/example2.erl
@@ -11,7 +11,7 @@
 
 -include("sw.hrl").
 
--import(sw, [mkTopLevel/4,xStart/1]).
+-import(sw, [mkTopLevel/4,xStart/0]).
 -import(lists, [flatten/1]).
 
 -define(bg, 16#ffffcc).
@@ -20,7 +20,7 @@ start() ->
     spawn_link(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     io:format("example2 Display=~p~n",[Display]),
     Win    = swTopLevel:make(Display, 240, 100, ?bg),
     Win ! {onClick, fun({_,X,Y,_,_}) -> io:format("Click ~p,~p~n",[X,Y]) end},

--- a/old_widgets/example20.erl
+++ b/old_widgets/example20.erl
@@ -12,7 +12,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 
 -include("sw.hrl").
 
@@ -21,7 +21,7 @@
 start() -> spawn(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win     = swTopLevel:make(Display, 400, 250, ?bg),
     Text    = swEdText:make(Win, 10,10,380,230,1,?white),
     S = self(),

--- a/old_widgets/example21.erl
+++ b/old_widgets/example21.erl
@@ -15,7 +15,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1, rpc/2]).
+-import(sw, [xStart/0, rpc/2]).
 
 -include("sw.hrl").
 -import(lists, [last/1, map/2, reverse/1]).
@@ -25,7 +25,7 @@
 start() -> spawn(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     swBlinker:ensure_blinker(Display),
     edit(Display, 80, 24, 
 "This is a very simple editor.

--- a/old_widgets/example22.erl
+++ b/old_widgets/example22.erl
@@ -15,7 +15,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 
 -include("sw.hrl").
 
@@ -24,7 +24,7 @@
 start() -> spawn(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win     = swTopLevel:make(Display, 670, 520, ?bg),
     swClock:make(Win, 10,10,440,1,?white),
     swClock:make(Win, 460,10,200,1,?white),

--- a/old_widgets/example23.erl
+++ b/old_widgets/example23.erl
@@ -12,7 +12,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -import(swCanvas, [newPen/4, draw/3, delete/2]).
 
 -include("sw.hrl").
@@ -22,7 +22,7 @@
 start() -> spawn(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win     = swTopLevel:make(Display, 460, 460, ?bg),
     Canvas  = swCanvas:make(Win, 10,10,440,440,1,?gray88),
     Self = self(),

--- a/old_widgets/example24.erl
+++ b/old_widgets/example24.erl
@@ -12,7 +12,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -import(swCanvas, [newPen/4, draw/3, delete/2]).
 
 -include("sw.hrl").
@@ -22,7 +22,7 @@
 start() -> spawn(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win     = swTopLevel:make(Display, 460, 460, ?bg),
     Self = self(),
     Win ! {onClick, fun({_,X,Y,_,_}) ->

--- a/old_widgets/example25.erl
+++ b/old_widgets/example25.erl
@@ -12,7 +12,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -import(swCanvas, [newPen/4, draw/3, delete/2]).
 
 -include("sw.hrl").
@@ -22,7 +22,7 @@
 start() -> spawn(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win     = swTopLevel:make(Display, 180, 80, ?bg),
     Self = self(),
     Win ! {onClick, fun({_,X,Y,_,_}) ->

--- a/old_widgets/example26.erl
+++ b/old_widgets/example26.erl
@@ -12,7 +12,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -import(swCanvas, [newPen/4, draw/3, delete/2]).
 
 -include("sw.hrl").
@@ -22,7 +22,7 @@
 start() -> spawn(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     XX = 40, YY=20,
     {Width, Ht} = sw:sizeInCols2pixels(XX, YY),
     Win     = swTopLevel:make(Display, Width+20, Ht+20, ?bg),

--- a/old_widgets/example27.erl
+++ b/old_widgets/example27.erl
@@ -13,7 +13,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -import(swCanvas, [newPen/4, draw/3, delete/2]).
 -import(lists, [foreach/2, map/2]).
 
@@ -28,7 +28,7 @@ start() -> spawn(fun win/0).
 %% So make box that is 360 wide 180 high
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Width = 720,
     Ht = 360,
     Win     = swTopLevel:make(Display, Width+20,Ht+20, ?bg),

--- a/old_widgets/example28.erl
+++ b/old_widgets/example28.erl
@@ -15,7 +15,7 @@
 
 -export([start/0, start/1]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -import(ex11_lib, [eListFonts/2,
 		   rpc/2, xDo/2
 		  ]).
@@ -42,7 +42,7 @@ start(File) ->
     spawn(fun() -> win(File) end).
 		  
 win(File) ->
-    Display = xStart("3.2"), 
+    Display = xStart(),
     Width   = 500, Ht = 400,
     Win     = swTopLevel:make(Display, Width, Ht, ?bg),
     Text    = swErlPoint:make(Win, 10,10, Width-20, Ht-20,1,?azure),

--- a/old_widgets/example29.erl
+++ b/old_widgets/example29.erl
@@ -12,7 +12,7 @@
 -include("sw.hrl").
 
 -import(swCanvas, [newPen/4, draw/3]).
--import(sw, [mkTopLevel/4,xStart/1,rpc/2]).
+-import(sw, [mkTopLevel/4,xStart/0,rpc/2]).
 -import(lists, [foldl/3,map/2,seq/2]).
 
 -define(bg, 16#ffffcc).
@@ -23,7 +23,7 @@ start() ->
     spawn_link(fun() -> win() end).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     P       = swLifts:make(),
     S = self(),
     P ! {onClick, fun(X) -> S ! X end},

--- a/old_widgets/example3.erl
+++ b/old_widgets/example3.erl
@@ -11,7 +11,7 @@
 
 -include("sw.hrl").
 
--import(sw, [mkTopLevel/4,xStart/1,rpc/2]).
+-import(sw, [mkTopLevel/4,xStart/0,rpc/2]).
 
 -define(bg, 16#ffffcc).
 
@@ -19,7 +19,7 @@ start() ->
     spawn_link(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win    = swTopLevel:make(Display, 350, 145, ?bg),
     Win ! {onClick, fun({_,X,Y,_,_}) -> io:format("Click ~p,~p~n",[X,Y]) end},
     _Label1  = swLabel:make(Win, 10, 10, 220, 30, 0, ?cornsilk, "First name:"),

--- a/old_widgets/example30.erl
+++ b/old_widgets/example30.erl
@@ -11,7 +11,7 @@
 
 -include("sw.hrl").
 
--import(sw, [mkTopLevel/4,rpc/2,xStart/1]).
+-import(sw, [mkTopLevel/4,rpc/2,xStart/0]).
 
 -define(bg, 16#ffffcc).
 
@@ -19,7 +19,7 @@ start() ->
     spawn_link(fun win/0).
 
 win() ->
-    Display  = xStart("3.2"),
+    Display  = xStart(),
     Win      = swTopLevel:make(Display, 160, 130, ?bg),
     Button1  = swButton:make(Win, 10, 10, 120, 30, ?grey88, "blue"),
     Button2  = swButton:make(Win, 10, 40,120,30,?grey88, "green"),

--- a/old_widgets/example31.erl
+++ b/old_widgets/example31.erl
@@ -17,7 +17,7 @@
 
 -export([start/0, start/1]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -import(ex11_lib, [rpc/2]).
 -import(lists, [duplicate/2,foldl/3,reverse/1, reverse/2]).
 
@@ -31,7 +31,7 @@ start(File) ->
     spawn(fun() -> win(File) end).
 		  
 win(File) ->
-    Display = xStart("3.2"), 
+    Display = xStart(),
     WidthCols = 80, HtCols=10,
     {Width, Ht} = sw:sizeInCols2pixels(WidthCols, HtCols),
     Win     = swTopLevel:make(Display, Width+20, Ht+20, ?bg),

--- a/old_widgets/example32.erl
+++ b/old_widgets/example32.erl
@@ -15,7 +15,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -import(ex11_lib, [rpc/2]).
 
 -include("sw.hrl").
@@ -26,7 +26,7 @@ start() ->
     spawn(fun() -> win() end).
 		  
 win() ->
-    Display = xStart("3.2"), 
+    Display = xStart(),
     Win     = swTopLevel:make(Display, 490, 470, ?bg),
     Win ! {onClick, fun(X) -> io:format("~p~n",[X]) end},
     Emacs1   = swEmacs:make(Win, 10,10, 50, 20,1,?white),

--- a/old_widgets/example4.erl
+++ b/old_widgets/example4.erl
@@ -11,7 +11,7 @@
 
 -include("sw.hrl").
 
--import(sw, [mkTopLevel/4,xStart/1,rpc/2]).
+-import(sw, [mkTopLevel/4,xStart/0,rpc/2]).
 
 -define(bg, 16#ffffcc).
 
@@ -19,7 +19,7 @@ start() ->
     spawn_link(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win    = swTopLevel:make(Display, 265, 100, ?bg),
     Win ! {onClick, fun({_,X,Y,_,_}) -> io:format("Click ~p,~p~n",[X,Y]) end},
     Label  = swLabel:make(Win, 10, 50, 250, 30, 0, ?grey90, ""),

--- a/old_widgets/example5.erl
+++ b/old_widgets/example5.erl
@@ -11,7 +11,7 @@
 
 -include("sw.hrl").
 
--import(sw, [mkTopLevel/4,xStart/1,rpc/2]).
+-import(sw, [mkTopLevel/4,xStart/0,rpc/2]).
 
 -define(bg, 16#ffffcc).
 
@@ -19,7 +19,7 @@ start() ->
     spawn_link(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win    = swTopLevel:make(Display, 235, 200, ?bg),
     Win ! {onClick, fun({_,X,Y,_,_}) -> io:format("Click ~p,~p~n",[X,Y]) end},
     S1  = swScrollbar:make(Win, 10, 10, 200, 30, 1, ?grey90, ?red),

--- a/old_widgets/example6.erl
+++ b/old_widgets/example6.erl
@@ -11,7 +11,7 @@
 
 -include("sw.hrl").
 
--import(sw, [mkTopLevel/4,xStart/1,rpc/2]).
+-import(sw, [mkTopLevel/4,xStart/0,rpc/2]).
 
 -define(bg, 16#ffffcc).
 
@@ -19,7 +19,7 @@ start() ->
     spawn_link(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win    = swTopLevel:make(Display, 230, 110, ?bg),
     Win ! {onClick, fun({_,X,Y,_,_}) -> io:format("Click ~p,~p~n",[X,Y]) end},
     Width  = swScrollbar:make(Win, 10, 10, 200, 20, 1, ?grey90, ?red),

--- a/old_widgets/example7.erl
+++ b/old_widgets/example7.erl
@@ -11,7 +11,7 @@
 
 -include("sw.hrl").
 
--import(sw, [mkTopLevel/4,xStart/1]).
+-import(sw, [mkTopLevel/4,xStart/0]).
 
 -define(bg, 16#ffffcc).
 
@@ -19,7 +19,7 @@ start() ->
     spawn_link(fun win/0).
 
 win() ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win     = swTopLevel:make(Display, 160, 50, ?bg),
     Button  = swButton:make(Win, 10, 10, 120, 30, ?grey88, "Hello"),
 

--- a/old_widgets/example8.erl
+++ b/old_widgets/example8.erl
@@ -9,7 +9,7 @@
 
 -export([start/0, join/3]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -import(ex11_lib, [rpc/2]).
 
 -include("sw.hrl").
@@ -20,7 +20,7 @@ start() ->
     spawn(fun win/0).
 
 win() ->
-    Display = xStart("3.1"),
+    Display = xStart(),
     Win  = swTopLevel:make(Display, 740, 460, ?bg),
     Win ! {onClick, fun({_,X,Y,_,_}) -> io:format("Click ~p,~p~n",[X,Y]) end},
     Text = swText:make(Win, 10, 10, 680, 400, ?AntiqueWhite, 

--- a/old_widgets/example9.erl
+++ b/old_widgets/example9.erl
@@ -9,7 +9,7 @@
 
 -export([start/0]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -import(example8, [join/3]).
 
 -include("sw.hrl").
@@ -23,7 +23,7 @@ win() ->
     show_file("intro.txt").
 
 show_file(File) ->
-    Display = xStart("3.1"),
+    Display = xStart(),
     Width = 850,
     Ht = 650,
     Win  = swTopLevel:make(Display, Width, Ht, ?bg),

--- a/old_widgets/fontSelector.erl
+++ b/old_widgets/fontSelector.erl
@@ -14,7 +14,7 @@
 
 -export([start/0, start/1]).
 
--import(sw,       [xStart/1,rpc/2]).
+-import(sw,       [xStart/0,rpc/2]).
 -import(ex11_lib, [eListFonts/2, eSetInputFocus/3, xDo/2, xFlush/1,  
 		   xColor/2, xCreateGC/2, xEnsureFont/2]).
 
@@ -31,7 +31,7 @@ start(File) ->
     spawn(fun() -> win(File) end).
 		  
 win(File) ->
-    Display = xStart("3.2"), 
+    Display = xStart(),
     Width = 700, Ht = 600,
     Win       = swTopLevel:make(Display, Width, Ht, ?bg),  
     Win ! {onClick, fun(X) -> io:format("Pos=~p~n",[X]) end},

--- a/old_widgets/startup_error_report
+++ b/old_widgets/startup_error_report
@@ -1,9 +1,0 @@
-$DISPLAY = :0.0
-parsed display Host=none DisplayNumber=0 ScreenNumber=0
-inet:gethostname() = "sredniczarny"
-Es
-{unix,"sredniczarny","Code1"}
-{unix,"localhost.localdomain","Code1"}
-Try list
-{unix,0,"Code1"}
-{{ip,"localhost"},0,"Code1"}

--- a/old_widgets/sw.erl
+++ b/old_widgets/sw.erl
@@ -11,7 +11,7 @@
 
 -export([sizeInCols2pixels/2, xyInCols2pixels/2,
 	 xyInPixels2cols/4, mkWindow/3, mkWindow/4, 
-	 xStart/1, generic/3,
+	 xStart/0, generic/3,
 	 rpc/2, raised_frame/4, reply/2, sunken_frame/4]).
 
 -import(ex11_lib, [eConfigureWindow/2,
@@ -53,8 +53,8 @@ xyInPixels2cols(X, Y, W, H) ->
 	  end,
     {XX1,YY1}.
 
-xStart(Vsn) ->
-    case ex11_lib:xStart(Vsn) of
+xStart() ->
+    case ex11_lib:xStart() of
 	{ok, Display} ->
 	    init(Display),
 	    Display;

--- a/old_widgets/swButton.erl
+++ b/old_widgets/swButton.erl
@@ -13,7 +13,7 @@
 -include("sw.hrl").
 
 -import(ex11_lib, [ePolyText8/5, rpc/2, sleep/1, 
-		   xClearArea/1,
+		   xClearArea/2,
 		   xDo/2, xFlush/1,
 		   xVar/2]).
 
@@ -49,7 +49,7 @@ loop(B, Display, Wargs, Fun) ->
 	    loop(B, Display, Wargs, Fun1);
 	{set, Str} ->
 	    Win = Wargs#win.win, 
-	    xDo(Display, xClearArea(Win)),
+	    xClearArea(Display, Win),
 	    Bin =  draw_cmd(Display, Wargs, Str),
 	    loop(Bin, Display, Wargs, Fun);
 	{'EXIT', Pid, Why} ->
@@ -72,7 +72,7 @@ flash(Display, Wargs) ->
     S = self(),
     Win=Wargs#win.win,
     spawn(fun() ->
-		  xDo(Display, xClearArea(Win)),
+		  xClearArea(Display, Win),
 		  xFlush(Display),
 		  sleep(200),
 		  S ! {event,Win, expose, void}

--- a/old_widgets/swCanvas.erl
+++ b/old_widgets/swCanvas.erl
@@ -18,7 +18,6 @@
 -include("sw.hrl").
 
 -import(ex11_lib, [ePolyText8/5, rpc/2, sleep/1, 
-		   xClearArea/1,
 		   eCopyArea/9,
 		   eFillPoly/5,
 		   ePolyArc/3,
@@ -30,7 +29,6 @@
 		   mkPoint/2,
 		   mkRectangle/4,
 		   reply/2,
-		   xClearArea/1,
 		   xColor/2,
 		   xCreateGC/2,
 		   xCreateGC/3,

--- a/old_widgets/swCanvas1.erl
+++ b/old_widgets/swCanvas1.erl
@@ -18,7 +18,6 @@
 -include("sw.hrl").
 
 -import(ex11_lib, [ePolyText8/5, rpc/2, sleep/1, 
-		   xClearArea/1,
 		   eCopyArea/9,
 		   eFillPoly/5,
 		   ePolyArc/3,
@@ -30,7 +29,6 @@
 		   mkPoint/2,
 		   mkRectangle/4,
 		   reply/2,
-		   xClearArea/1,
 		   xColor/2,
 		   xCreateGC/2,
 		   xCreateGC/3,

--- a/old_widgets/swClock.erl
+++ b/old_widgets/swClock.erl
@@ -14,13 +14,11 @@
 -include("sw.hrl").
 
 -import(ex11_lib, [ePolyText8/5, rpc/2, sleep/1, 
-		   xClearArea/1,
 		   eCopyArea/9,
 		   ePolyFillRectangle/3,
 		   ePolyLine/4,
 		   mkPoint/2,
 		   mkRectangle/4,
-		   xClearArea/1,
 		   xColor/2,
 		   xCreateGC/2,
 		   xCreatePixmap/4,

--- a/old_widgets/swColorButton.erl
+++ b/old_widgets/swColorButton.erl
@@ -15,7 +15,7 @@
 		   eConfigureWindow/2,reply/2, ePolyFillRectangle/3,
 		   ePolyText8/5,eUnmapWindow/1,eMapWindow/1,
 		   mkRectangle/4,rpc/2,sleep/1,xCreateGC/2,
-		   xClearArea/1,xColor/2,
+		   xColor/2,
 		   xDo/2,xFlush/1,xVar/2]).
 
 -include("sw.hrl").

--- a/old_widgets/swColorText.erl
+++ b/old_widgets/swColorText.erl
@@ -23,7 +23,6 @@
 
 -import(ex11_lib, [eImageText8/5,
 		   ePolyText8/5, rpc/2, sleep/1, 
-		   xClearArea/1,
 		   xCreateGC/2,
 		   xColor/2,
 		   xDo/2, 

--- a/old_widgets/swEdText.erl
+++ b/old_widgets/swEdText.erl
@@ -14,7 +14,7 @@
 -include("sw.hrl").
 
 -import(ex11_lib, [ePolyText8/5, reply/2, rpc/2, sleep/1, 
-		   xClearArea/1,
+		   xClearArea/2,
 		   xDo/2, xFlush/1,
 		   xVar/2]).
 -import(lists, [mapfoldl/3]).
@@ -58,7 +58,7 @@ loop(Display, Wargs, GC, W, H, F1, F2, F3) ->
 	    loop(Display, Wargs, GC, W, H, F1, F2, F3);
 	{show, Strs} ->
 	    Win = Wargs#win.win, 
-	    xDo(Display, xClearArea(Win)),
+	    xClearArea(Display, Win),
 	    F = make_expose_fun(Strs, Win, GC, W, H, Display),
 	    F(),
 	    loop(Display, Wargs, GC, W, H, F, F2, F3);

--- a/old_widgets/swEmacs.erl
+++ b/old_widgets/swEmacs.erl
@@ -17,7 +17,7 @@
 
 -export([make/7]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -import(ex11_lib, [rpc/2]).
 -import(lists, [duplicate/2,foldl/3,reverse/1, reverse/2]).
 

--- a/old_widgets/swEntry.erl
+++ b/old_widgets/swEntry.erl
@@ -18,7 +18,7 @@
 		  ePolyText8/5,
 		  mkRectangle/4,
 		  rpc/2,
-		  xClearArea/1,
+		  xClearArea/2,
 		  xColor/2,
 		  xCreateGC/2,
 		  xCreatePixmap/4,
@@ -123,7 +123,7 @@ fix_entry(Display, Entry, Data, Fun) ->
     B = [ePolyText8(Entry, xGC(Display, "text"), 4, 15, Str)|
 	 sw:sunken_frame(Display, Entry, Width, Ht)],
     Draw = fun() -> xDo(Display, B) end,
-    xDo(Display, xClearArea(Entry)),
+    xClearArea(Display, Entry),
     Draw(),
     XX = 9*N+5, YY = 4,
     swBlinker:blink(Display, Entry, XX, YY),

--- a/old_widgets/swErlPoint.erl
+++ b/old_widgets/swErlPoint.erl
@@ -25,7 +25,6 @@
 		   ePolyText8/5, 
 		   mkRectangle/4,
 		   rpc/2, sleep/1, 
-		   xClearArea/1,
 		   xCreateGC/2,
 		   xCreateGC/3,
 		   xColor/2,

--- a/old_widgets/swFlashButton.erl
+++ b/old_widgets/swFlashButton.erl
@@ -15,7 +15,7 @@
 		   eConfigureWindow/2,reply/2, ePolyFillRectangle/3,
 		   ePolyText8/5,eUnmapWindow/1,eMapWindow/1,
 		   mkRectangle/4,rpc/2,sleep/1,xCreateGC/2,
-		   xClearArea/1,xColor/2,
+		   xClearArea/2,xColor/2,
 		   xDo/2,xFlush/1,xVar/2]).
 
 -include("sw.hrl").
@@ -100,7 +100,7 @@ loop(Display, Fun, FunE, FunL, Enter,Leave,Wargs) ->
 
 flash(Display, Win, Draw) ->
     spawn(fun() ->
-		  xDo(Display, xClearArea(Win)),
+		  xClearArea(Display, Win),
 		  xFlush(Display),
 		  sleep(200),
 		  Draw(),

--- a/old_widgets/swLabel.erl
+++ b/old_widgets/swLabel.erl
@@ -12,7 +12,7 @@
 -include("sw.hrl").
 
 -import(ex11_lib, [ePolyText8/5, rpc/2, sleep/1, 
-		   xClearArea/1,
+		   xClearArea/2,
 		   xDo/2, xFlush/1,
 		   xVar/2]).
 
@@ -38,7 +38,7 @@ loop(B, Display, Wargs) ->
 	    loop(B, Display, Wargs);
 	{set, Str} ->
 	    Win = Wargs#win.win, 
-	    xDo(Display, xClearArea(Win)),
+	    xClearArea(Display, Win),
 	    Bin =  ePolyText8(Win, xVar(Display, sysFontId), 10, 18, Str),
 	    self() ! {event,void,expose,void},
 	    loop(Bin, Display, Wargs);

--- a/old_widgets/swLifts.erl
+++ b/old_widgets/swLifts.erl
@@ -12,7 +12,7 @@
 -include("sw.hrl").
 
 -import(swCanvas, [newPen/4, draw/3]).
--import(sw, [mkTopLevel/4,xStart/1,rpc/2]).
+-import(sw, [mkTopLevel/4,xStart/0,rpc/2]).
 -import(lists, [foldl/3,map/2,reverse/1,seq/2]).
 
 -define(bg, 16#ffffcc).
@@ -31,7 +31,7 @@ make() ->
     end.
 
 win(Parent) ->
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win0    = swTopLevel:make(Display, 645, 710, ?bg),
     Canvas  = swCanvas:make(Win0, 10,10,625,690,1,?LightCyan),
     Canvas ! {onClick,fun({_,X,Y,_,_})->io:format("Click ~p,~p~n",[X,Y]) end},

--- a/old_widgets/swProgressBar.erl
+++ b/old_widgets/swProgressBar.erl
@@ -15,7 +15,6 @@
 		   eMapWindow/1,
 		   ePolyText8/5, rpc/2, sleep/1, 
 		   xColor/2,
-		   xClearArea/1,
 		   xCreateCursor/2,
 		   xCreateWindow/10,
 		   xDo/2, xFlush/1,

--- a/old_widgets/swRectangle.erl
+++ b/old_widgets/swRectangle.erl
@@ -12,7 +12,6 @@
 -include("sw.hrl").
 
 -import(ex11_lib, [ePolyText8/5, rpc/2, sleep/1, 
-		   xClearArea/1,
 		   xDo/2, xFlush/1,
 		   xVar/2]).
 

--- a/old_widgets/swScrollbar.erl
+++ b/old_widgets/swScrollbar.erl
@@ -15,7 +15,6 @@
 		   eMapWindow/1,
 		   ePolyText8/5, rpc/2, sleep/1, 
 		   xColor/2,
-		   xClearArea/1,
 		   xCreateCursor/2,
 		   xCreateWindow/10,
 		   xDo/2, xFlush/1,

--- a/old_widgets/swSelector.erl
+++ b/old_widgets/swSelector.erl
@@ -15,7 +15,7 @@
 
 -export([make/7]).
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 -import(ex11_lib, [eListFonts/2, xDo/2, rpc/2]).
 -import(lists, [duplicate/2,foldl/3,map/2,member/2,reverse/1, 
 		reverse/2, sort/1]).

--- a/old_widgets/swText.erl
+++ b/old_widgets/swText.erl
@@ -14,7 +14,7 @@
 		   rpc/2,
 		   xAddAction/2,
 		   xAddHandler/2,
-		   xClearArea/1,
+		   xClearArea/2,
 		   xColor/2,
 		   xDo/2,
 		   xFlush/1,
@@ -105,7 +105,7 @@ refresh(Display, Text, N,MaxHt, Ht, TextBuff, K0) ->
 	K == K0 ->
 	    noChange;
 	true ->
-	    xDo(Display, xClearArea(Text)),
+	    xClearArea(Display, Text),
 	    {Strs, TextBuff1} = get_screen(MaxHt, K, TextBuff),
 	    GC = xVar(Display, sysFontId),
 	    B = add_text(Text, GC, Strs),

--- a/old_widgets/swToggle.erl
+++ b/old_widgets/swToggle.erl
@@ -15,7 +15,7 @@
 		   eConfigureWindow/2,reply/2, ePolyFillRectangle/3,
 		   ePolyText8/5,eUnmapWindow/1,eMapWindow/1,
 		   mkRectangle/4,rpc/2,sleep/1,xCreateGC/2,
-		   xClearArea/1,xColor/2,
+		   xClearArea/2,xColor/2,
 		   xDo/2,xFlush/1,xVar/2]).
 
 -include("sw.hrl").
@@ -100,7 +100,7 @@ loop(Display, Fun, FunE, FunL, Enter,Leave,Wargs) ->
 
 flash(Display, Win, Draw) ->
     spawn(fun() ->
-		  xDo(Display, xClearArea(Win)),
+		  xClearArea(Display, Win),
 		  xFlush(Display),
 		  sleep(200),
 		  Draw(),

--- a/old_widgets/swTopLevel.erl
+++ b/old_widgets/swTopLevel.erl
@@ -16,7 +16,7 @@
 
 -import(ex11_lib,
 	[reply/2, reply/2, rpc/2, get_display/2, get_root_of_screen/2,
-	 xClearArea/1, xColor/2, xCreateGC/3, xDo/2, xFlush/1]).
+	 xClearArea/2, xColor/2, xCreateGC/3, xDo/2, xFlush/1]).
 
 -import(lists, [foreach/2]).
 
@@ -108,7 +108,7 @@ loop(Display, Wargs, Pens, L, Fun, CFun) ->
     end.
 
 refresh(Display, Win, {L,_}) ->
-    xDo(Display, xClearArea(Win)),
+    xClearArea(Display, Win),
     foreach(fun({_,Bin}) -> xDo(Display, Bin) end, L),
     xFlush(Display).
 

--- a/old_widgets/test1.erl
+++ b/old_widgets/test1.erl
@@ -11,7 +11,7 @@
 
 -include("sw.hrl").
 
--import(sw, [xStart/1]).
+-import(sw, [xStart/0]).
 
 -define(bg, 16#ffffcc).
 
@@ -23,7 +23,7 @@ start() ->
 
 win() ->
     process_flag(trap_exit, true),
-    Display = xStart("3.2"),
+    Display = xStart(),
     Win    = swTopLevel:make(Display, 450, 170, ?bg),
     io:format("top win=~p~n",[Win]),
     Win ! {onClick, fun({_,X,Y,_,_}) -> io:format("Click ~p,~p~n",[X,Y]) end},

--- a/widgets/main.erl
+++ b/widgets/main.erl
@@ -10,7 +10,7 @@ start() -> spawn(?MODULE,init,[]).
 
 init() ->
 	Pid = self(),
-	{ok, Display} = ex11_lib:xStart(":0.0"),
+	{ok, Display} = ex11_lib:xStart(),
     xSetScreenSaver(Display,0),
 	Win = xCreateSimpleWindow(Display,0,0,?WT,?HT,?XC_arrow,xColor(Display,?black)),
 	xDo(Display, eMapWindow(Win)),


### PR DESCRIPTION
Hi,

It looks like the old meaning of the argument to xStart/1 changed to be the display identifier (is that the right word?), instead of a minimum library version. And at the same time, the library lost the ability to read the DISPLAY environment variable where it's usually kept. This made the library not work at all for me, since I'm using remote X.

While I was fixing things, I also changed the calls to xClearArea to match how it had changed.  Now I can run the old demo and the new demo.