### PR TITLE
allow setting window title, and min/max size

### DIFF
--- a/lib/hello_world.erl
+++ b/lib/hello_world.erl
@@ -38,6 +38,9 @@ init() ->
     Cmd =  ePolyText8(Win, Pen, 10, 35, "Hello World"),
     xDo(Pid, Cmd),
     xDo(Pid, eMapWindow(Win)),
+    % Hello World + Waving Hand Sign (U+1F44B); Emoji support seems mixed
+    ex11_lib:xSetWMName(Pid, Win, <<"Hello World", 16#F0, 16#9F, 16#91, 16#8B>>),
+    ex11_lib:xSetNormalHints(Pid, Win, [{min_size, 300, 100}, {max_size, 300, 100}]),
     xFlush(Pid),
     loop(Pid, Win, Cmd).
 


### PR DESCRIPTION
I've added a couple features to communicate with window managers.

Setting emoji in window title doesn't seem to work everywhere (worked against X server for mac, but not VcXsrv for windows, even though it looks like they're doing the right things).

Setting window min/max size seems well supported, and is nice for windows you don't want resized.

Other things could certainly be added, but these scratch my itches.